### PR TITLE
feat: add vote percentage display for parties

### DIFF
--- a/src/components/details/DetailPanel.tsx
+++ b/src/components/details/DetailPanel.tsx
@@ -1,6 +1,18 @@
 import { useState } from 'react';
-import type { LocalBody, Ward, PollingStation, TrendResult } from '../../services/dataService';
-import { ArrowLeft, MapPin, Vote, Users, Building2, Trophy } from 'lucide-react';
+import type {
+    LocalBody,
+    Ward,
+    PollingStation,
+    TrendResult,
+} from '../../services/dataService';
+import {
+    ArrowLeft,
+    MapPin,
+    Vote,
+    Users,
+    Building2,
+    Trophy,
+} from 'lucide-react';
 import { SVGMap } from '../map/SVGMap';
 import { WardDetailModal } from './WardDetailModal';
 
@@ -13,289 +25,743 @@ interface DetailPanelProps {
     trendData?: TrendResult;
 }
 
-export const DetailPanel: React.FC<DetailPanelProps> = ({ localBody, onBack, wards, pollingStations, localBodies, trendData }) => {
+export const DetailPanel: React.FC<DetailPanelProps> = ({
+    localBody,
+    onBack,
+    wards,
+    pollingStations,
+    localBodies,
+    trendData,
+}) => {
+    console.log(trendData);
 
     const [selectedWard, setSelectedWard] = useState<string | null>(null);
 
     // SVG Map handles coloring internally now.
     // Preserving logic structure if we ever need to pass raw GeoJSON again, but cleaning up heavy processing.
 
-    const lbWards = wards.filter(w => w.lb_code === localBody.lb_code);
+    const lbWards = wards.filter((w) => w.lb_code === localBody.lb_code);
 
     let totalPollingStations = 0;
 
     if (localBody.lb_type === 'District Panchayat') {
         // Aggregate polling stations for the entire district
         // User requested to ONLY include Grama Panchayats for District Panchayat count
-        const districtGPs = localBodies.filter(lb =>
-            lb.district_name === localBody.district_name && lb.lb_type === 'Grama Panchayat'
+        const districtGPs = localBodies.filter(
+            (lb) =>
+                lb.district_name === localBody.district_name &&
+                lb.lb_type === 'Grama Panchayat',
         );
-        const districtGPCodes = new Set(districtGPs.map(lb => lb.lb_code));
+        const districtGPCodes = new Set(districtGPs.map((lb) => lb.lb_code));
 
         // Count polling stations belonging to these GPs
-        totalPollingStations = pollingStations.filter(ps => districtGPCodes.has(ps.lb_code)).length;
+        totalPollingStations = pollingStations.filter((ps) =>
+            districtGPCodes.has(ps.lb_code),
+        ).length;
     } else {
         // Base tiers and Block Panchayat
         // For Block Panchayat, we now have rows in polling_stations.csv with the Block Code
-        const lbPollingStations = pollingStations.filter(ps => ps.lb_code === localBody.lb_code);
+        const lbPollingStations = pollingStations.filter(
+            (ps) => ps.lb_code === localBody.lb_code,
+        );
         totalPollingStations = lbPollingStations.length;
     }
 
-    const totalVoters = lbWards.reduce((acc, curr) => acc + curr.total_voters, 0);
+    const totalVoters = lbWards.reduce(
+        (acc, curr) => acc + curr.total_voters,
+        0,
+    );
 
     return (
-        <div className="flex flex-col h-full bg-slate-50 shadow-xl z-30 relative">
-            <div className="p-6 border-b border-slate-200 bg-white flex items-center gap-4 shadow-sm">
+        <div className='flex flex-col h-full bg-slate-50 shadow-xl z-30 relative'>
+            <div className='p-6 border-b border-slate-200 bg-white flex items-center gap-4 shadow-sm'>
                 <button
                     onClick={onBack}
-                    className="p-2.5 hover:bg-slate-100 rounded-xl transition-all text-slate-500 hover:text-slate-800 border border-transparent hover:border-slate-200"
+                    className='p-2.5 hover:bg-slate-100 rounded-xl transition-all text-slate-500 hover:text-slate-800 border border-transparent hover:border-slate-200'
                 >
                     <ArrowLeft size={20} />
                 </button>
-                <div className="flex-1 min-w-0">
-                    <h2 className="text-2xl font-bold text-slate-900 truncate tracking-tight">{localBody.lb_name_english}</h2>
-                    <p className="text-sm text-slate-500 truncate">Local Body Details</p>
+                <div className='flex-1 min-w-0'>
+                    <h2 className='text-2xl font-bold text-slate-900 truncate tracking-tight'>
+                        {localBody.lb_name_english}
+                    </h2>
+                    <p className='text-sm text-slate-500 truncate'>
+                        Local Body Details
+                    </p>
                 </div>
             </div>
 
-            <div className="flex-1 overflow-y-auto custom-scrollbar">
+            <div className='flex-1 overflow-y-auto custom-scrollbar'>
                 {/* Map Section */}
-                <div className="h-64 w-full bg-slate-200 relative">
+                <div className='h-64 w-full bg-slate-200 relative'>
                     <SVGMap
-                        url={`${import.meta.env.BASE_URL}data/geojson/Kerala/district_wards/${(localBody.district_name === 'Thiruvanathapuram' ? 'Thiruvananthapuram' : localBody.district_name)}/${localBody.lb_code}.svg`}
-
+                        url={`${import.meta.env.BASE_URL}data/geojson/Kerala/district_wards/${localBody.district_name === 'Thiruvanathapuram' ? 'Thiruvananthapuram' : localBody.district_name}/${localBody.lb_code}.svg`}
                         trendData={trendData}
                         onWardClick={(wardNo) => setSelectedWard(wardNo)}
                     />
                 </div>
 
-                <div className="p-6">
-                    <div className="mb-8 flex flex-wrap gap-2 justify-between items-center">
-                        <span className="inline-flex items-center px-4 py-1.5 bg-blue-50 text-blue-700 rounded-full text-sm font-semibold border border-blue-100 shadow-sm">
+                <div className='p-6'>
+                    <div className='mb-8 flex flex-wrap gap-2 justify-between items-center'>
+                        <span className='inline-flex items-center px-4 py-1.5 bg-blue-50 text-blue-700 rounded-full text-sm font-semibold border border-blue-100 shadow-sm'>
                             {localBody.lb_type} • {localBody.district_name}
                         </span>
                     </div>
 
                     {/* Election Trends Section */}
-                    {trendData && (
-                        <div className="mb-8 bg-white rounded-2xl border border-slate-200 shadow-sm p-5">
-                            <h3 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-2">
-                                <Trophy size={20} className="text-yellow-500" />
-                                Election Trends 2025
-                            </h3>
+                    {trendData &&
+                        (() => {
+                            // Compute party-level vote totals and wins from wardInfo
+                            const groupMap: Record<string, string> = {
+                                LDF: 'LDF',
+                                UDF: 'UDF',
+                                NDA: 'NDA',
+                                OTHERS: 'Others',
+                            };
 
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                {/* Leading Front Banner */}
-                                <div className="bg-gradient-to-br from-slate-50 to-white border border-slate-200 rounded-xl p-4 flex flex-col justify-center items-center text-center">
-                                    <span className="text-xs uppercase font-bold text-slate-500 mb-1">Leading Front</span>
-                                    <div className={`text-4xl font-black ${trendData.Leading_Front === 'LDF' ? 'text-red-600' :
-                                        trendData.Leading_Front === 'UDF' ? 'text-indigo-600' :
-                                            trendData.Leading_Front === 'NDA' ? 'text-orange-600' : 'text-slate-700'
-                                        }`}>
-                                        {trendData.Leading_Front}
-                                    </div>
-                                    <span className="text-sm font-medium text-slate-500 mt-2">
-                                        {trendData.Wards_Declared} of {localBody.total_wards} Declared
-                                    </span>
-                                </div>
+                            const frontVotes: Record<string, number> = {
+                                LDF: 0,
+                                UDF: 0,
+                                NDA: 0,
+                                Others: 0,
+                            };
+                            const partyVotes: Record<string, number> = {};
+                            const partyWins: Record<string, number> = {};
+                            console.log('Party votes:', partyVotes);
+                            if (trendData.wardInfo) {
+                                Object.values(trendData.wardInfo).forEach(
+                                    (ward) => {
+                                        ward.candidates?.forEach((c) => {
+                                            const g =
+                                                groupMap[c.group] ?? 'Others';
+                                            frontVotes[g] =
+                                                (frontVotes[g] ?? 0) +
+                                                (c.votes ?? 0);
+                                            const key = `${g}::${c.party}`;
+                                            partyVotes[key] =
+                                                (partyVotes[key] ?? 0) +
+                                                (c.votes ?? 0);
+                                        });
+                                        if (ward.winner) {
+                                            const g =
+                                                groupMap[ward.winner.group] ??
+                                                'Others';
+                                            const key = `${g}::${ward.winner.party}`;
+                                            partyWins[key] =
+                                                (partyWins[key] ?? 0) + 1;
+                                        }
+                                    },
+                                );
+                            }
 
-                                {/* Seat Distribution */}
-                                <div className="space-y-3">
-                                    <div className="text-sm font-semibold text-slate-600 mb-2">Seat Distribution</div>
-                                    <div className="space-y-2">
-                                        {[
-                                            { label: 'LDF', value: trendData.LDF_Seats, color: 'bg-red-500', text: 'text-red-700' },
-                                            { label: 'UDF', value: trendData.UDF_Seats, color: 'bg-indigo-500', text: 'text-indigo-700' },
-                                            { label: 'NDA', value: trendData.NDA_Seats, color: 'bg-orange-500', text: 'text-orange-700' },
-                                            { label: 'Others', value: trendData.IND_Seats, color: 'bg-slate-400', text: 'text-slate-700' },
-                                        ].map(item => (
-                                            <div key={item.label} className="flex items-center gap-3">
-                                                <div className="w-12 text-xs font-bold text-slate-500">{item.label}</div>
-                                                <div className="flex-1 h-3 bg-slate-100 rounded-full overflow-hidden">
-                                                    <div
-                                                        className={`h-full ${item.color}`}
-                                                        style={{ width: `${(item.value / localBody.total_wards) * 100}%` }}
-                                                    ></div>
-                                                </div>
-                                                <div className={`w-6 text-sm font-bold text-right ${item.text}`}>{item.value}</div>
+                            const totalVotes = Object.values(frontVotes).reduce(
+                                (a, b) => a + b,
+                                0,
+                            );
+                            console.log('Front Votes:', frontVotes);
+                            console.log('totalVotes:', totalVotes);
+                            const fronts = [
+                                {
+                                    label: 'LDF',
+                                    value: trendData.LDF_Seats,
+                                    color: 'bg-red-500',
+                                    text: 'text-red-700',
+                                    dotColor: 'bg-red-400',
+                                    voteColor: 'text-red-600',
+                                },
+                                {
+                                    label: 'UDF',
+                                    value: trendData.UDF_Seats,
+                                    color: 'bg-indigo-500',
+                                    text: 'text-indigo-700',
+                                    dotColor: 'bg-indigo-400',
+                                    voteColor: 'text-indigo-600',
+                                },
+                                {
+                                    label: 'NDA',
+                                    value: trendData.NDA_Seats,
+                                    color: 'bg-orange-500',
+                                    text: 'text-orange-700',
+                                    dotColor: 'bg-orange-400',
+                                    voteColor: 'text-orange-600',
+                                },
+                                {
+                                    label: 'Others',
+                                    value: trendData.IND_Seats,
+                                    color: 'bg-slate-400',
+                                    text: 'text-slate-600',
+                                    dotColor: 'bg-slate-300',
+                                    voteColor: 'text-slate-500',
+                                },
+                            ];
+
+                            return (
+                                <div className='mb-8 bg-white rounded-2xl border border-slate-200 shadow-sm p-5'>
+                                    <h3 className='text-lg font-bold text-slate-900 mb-4 flex items-center gap-2'>
+                                        <Trophy
+                                            size={20}
+                                            className='text-yellow-500'
+                                        />
+                                        Election Trends 2025
+                                    </h3>
+
+                                    <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+                                        {/* Leading Front Banner */}
+                                        <div className='bg-gradient-to-br from-slate-50 to-white border border-slate-200 rounded-xl p-4 flex flex-col justify-center items-center text-center'>
+                                            <span className='text-xs uppercase font-bold text-slate-500 mb-1'>
+                                                Leading Front
+                                            </span>
+                                            <div
+                                                className={`text-4xl font-black ${
+                                                    trendData.Leading_Front ===
+                                                    'LDF'
+                                                        ? 'text-red-600'
+                                                        : trendData.Leading_Front ===
+                                                            'UDF'
+                                                          ? 'text-indigo-600'
+                                                          : trendData.Leading_Front ===
+                                                              'NDA'
+                                                            ? 'text-orange-600'
+                                                            : 'text-slate-700'
+                                                }`}
+                                            >
+                                                {trendData.Leading_Front}
                                             </div>
-                                        ))}
+                                            <span className='text-sm font-medium text-slate-500 mt-2'>
+                                                {trendData.Wards_Declared} of{' '}
+                                                {localBody.total_wards} Declared
+                                            </span>
+
+                                            {/* Stacked bar showing all fronts proportionally */}
+                                            <div className='w-full mt-4 h-2 bg-slate-100 rounded-full overflow-hidden flex'>
+                                                {fronts.map((f) => (
+                                                    <div
+                                                        key={f.label}
+                                                        className={`h-full ${f.color}`}
+                                                        style={{
+                                                            width: `${(f.value / localBody.total_wards) * 100}%`,
+                                                        }}
+                                                    />
+                                                ))}
+                                            </div>
+                                            <div className='flex gap-3 mt-2 flex-wrap justify-center'>
+                                                {fronts
+                                                    .filter((f) => f.value > 0)
+                                                    .map((f) => (
+                                                        <span
+                                                            key={f.label}
+                                                            className='flex items-center gap-1 text-xs text-slate-500'
+                                                        >
+                                                            <span
+                                                                className={`w-2 h-2 rounded-full ${f.dotColor} inline-block`}
+                                                            />
+                                                            {f.label}
+                                                        </span>
+                                                    ))}
+                                            </div>
+                                        </div>
+
+                                        {/* Seat Distribution */}
+                                        <div className='space-y-1'>
+                                            <div className='text-sm font-semibold text-slate-600 mb-3'>
+                                                Seat Distribution
+                                            </div>
+                                            <div className='space-y-3'>
+                                                {fronts.map((item) => {
+                                                    const seatPct = Math.round(
+                                                        (item.value /
+                                                            localBody.total_wards) *
+                                                            100,
+                                                    );
+                                                    const votes =
+                                                        frontVotes[
+                                                            item.label
+                                                        ] ?? 0;
+                                                    const votePct =
+                                                        totalVotes > 0
+                                                            ? (
+                                                                  (votes /
+                                                                      totalVotes) *
+                                                                  100
+                                                              ).toFixed(1)
+                                                            : '0.0';
+
+                                                    // Party breakdown for this front
+                                                    const partyKeys =
+                                                        Object.keys(
+                                                            partyWins,
+                                                        ).filter((k) =>
+                                                            k.startsWith(
+                                                                item.label +
+                                                                    '::',
+                                                            ),
+                                                        );
+
+                                                    return (
+                                                        <div key={item.label}>
+                                                            {/* Front row */}
+                                                            <div className='flex items-center gap-3'>
+                                                                <div className='w-12 text-xs font-bold text-slate-500'>
+                                                                    {item.label}
+                                                                </div>
+                                                                <div className='flex-1 h-2.5 bg-slate-100 rounded-full overflow-hidden'>
+                                                                    <div
+                                                                        className={`h-full ${item.color} rounded-full`}
+                                                                        style={{
+                                                                            width: `${seatPct}%`,
+                                                                        }}
+                                                                    />
+                                                                </div>
+                                                                <div className='flex items-baseline gap-1.5 min-w-[64px] justify-end'>
+                                                                    <span
+                                                                        className={`text-sm font-bold ${item.text}`}
+                                                                    >
+                                                                        {
+                                                                            item.value
+                                                                        }
+                                                                    </span>
+                                                                    <span className='text-[11px] text-slate-400 font-medium'>
+                                                                        {
+                                                                            seatPct
+                                                                        }
+                                                                        %
+                                                                    </span>
+                                                                </div>
+                                                            </div>
+
+                                                            {/* Vote share row */}
+                                                            {totalVotes > 0 && (
+                                                                <div className='flex items-center gap-3 mt-0.5'>
+                                                                    <div className='w-12' />
+                                                                    <div className='flex-1 h-1 bg-slate-100 rounded-full overflow-hidden'>
+                                                                        <div
+                                                                            className={`h-full ${item.color} opacity-30 rounded-full`}
+                                                                            style={{
+                                                                                width: `${votePct}%`,
+                                                                            }}
+                                                                        />
+                                                                    </div>
+                                                                    <div className='min-w-[64px] text-right'>
+                                                                        <span className='text-[11px] text-slate-400'>
+                                                                            {Number(
+                                                                                votePct,
+                                                                            ).toFixed(
+                                                                                1,
+                                                                            )}
+                                                                            %
+                                                                            votes
+                                                                        </span>
+                                                                    </div>
+                                                                </div>
+                                                            )}
+
+                                                            {/* Party breakdown */}
+                                                            {partyKeys.length >
+                                                                0 && (
+                                                                <div className='ml-12 mt-1.5 space-y-1'>
+                                                                    {partyKeys
+                                                                        .sort(
+                                                                            (
+                                                                                a,
+                                                                                b,
+                                                                            ) =>
+                                                                                (partyWins[
+                                                                                    b
+                                                                                ] ??
+                                                                                    0) -
+                                                                                (partyWins[
+                                                                                    a
+                                                                                ] ??
+                                                                                    0),
+                                                                        )
+                                                                        .map(
+                                                                            (
+                                                                                k,
+                                                                            ) => {
+                                                                                const party =
+                                                                                    k.split(
+                                                                                        '::',
+                                                                                    )[1];
+                                                                                const wins =
+                                                                                    partyWins[
+                                                                                        k
+                                                                                    ] ??
+                                                                                    0;
+                                                                                const pVotes =
+                                                                                    partyVotes[
+                                                                                        k
+                                                                                    ] ??
+                                                                                    0;
+                                                                                const pVotePct =
+                                                                                    totalVotes >
+                                                                                    0
+                                                                                        ? (
+                                                                                              (pVotes /
+                                                                                                  totalVotes) *
+                                                                                              100
+                                                                                          ).toFixed(
+                                                                                              1,
+                                                                                          )
+                                                                                        : '0.0';
+                                                                                return (
+                                                                                    <div
+                                                                                        key={
+                                                                                            k
+                                                                                        }
+                                                                                        className='flex items-center gap-2 text-[11px] text-slate-500'
+                                                                                    >
+                                                                                        <span
+                                                                                            className={`w-1.5 h-1.5 rounded-full ${item.dotColor} inline-block shrink-0`}
+                                                                                        />
+                                                                                        <span className='flex-1 truncate'>
+                                                                                            {
+                                                                                                party
+                                                                                            }
+                                                                                        </span>
+                                                                                        <span className='font-semibold text-slate-600'>
+                                                                                            {
+                                                                                                wins
+                                                                                            }
+
+                                                                                            W
+                                                                                        </span>
+                                                                                        {totalVotes >
+                                                                                            0 && (
+                                                                                            <span className='text-slate-400 min-w-[44px] text-right'>
+                                                                                                {
+                                                                                                    pVotePct
+                                                                                                }
+
+                                                                                                %
+                                                                                            </span>
+                                                                                        )}
+                                                                                    </div>
+                                                                                );
+                                                                            },
+                                                                        )}
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                    )}
+                            );
+                        })()}
 
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 md:gap-4">
+                    <div className='grid grid-cols-1 sm:grid-cols-2 gap-2 md:gap-4'>
                         {/* Voters Card - Full width on mobile, spans 2 rows on larger screens */}
-                        <div className="sm:row-span-2 p-3 md:p-5 bg-white rounded-2xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow flex flex-col">
-                            <div className="flex items-start gap-3 md:gap-4 mb-4">
-                                <div className="p-3 bg-indigo-50 text-indigo-600 rounded-xl shrink-0">
+                        <div className='sm:row-span-2 p-3 md:p-5 bg-white rounded-2xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow flex flex-col'>
+                            <div className='flex items-start gap-3 md:gap-4 mb-4'>
+                                <div className='p-3 bg-indigo-50 text-indigo-600 rounded-xl shrink-0'>
                                     <Vote size={24} />
                                 </div>
                                 <div>
-                                    <p className="text-xs md:text-sm font-medium text-slate-500 mb-1">Total Voters</p>
-                                    <p className="text-2xl md:text-3xl font-bold text-slate-900">{totalVoters.toLocaleString()}</p>
+                                    <p className='text-xs md:text-sm font-medium text-slate-500 mb-1'>
+                                        Total Voters
+                                    </p>
+                                    <p className='text-2xl md:text-3xl font-bold text-slate-900'>
+                                        {totalVoters.toLocaleString()}
+                                    </p>
                                 </div>
                             </div>
 
                             {/* Gender Split - Pushed to bottom / Expanded */}
-                            <div className="mt-auto pt-4 border-t border-slate-100">
-                                <div className="flex items-center gap-2 mb-3">
-                                    <div className="h-2 flex-1 rounded-full bg-slate-100 overflow-hidden flex">
-                                        <div className="bg-blue-500 h-full" style={{ width: `${(lbWards.reduce((acc, curr) => acc + (curr.male_voters || 0), 0) / totalVoters) * 100}%` }} />
-                                        <div className="bg-pink-500 h-full" style={{ width: `${(lbWards.reduce((acc, curr) => acc + (curr.female_voters || 0), 0) / totalVoters) * 100}%` }} />
-                                        <div className="bg-slate-400 h-full" style={{ width: `${(lbWards.reduce((acc, curr) => acc + (curr.other_voters || 0), 0) / totalVoters) * 100}%` }} />
+                            <div className='mt-auto pt-4 border-t border-slate-100'>
+                                <div className='flex items-center gap-2 mb-3'>
+                                    <div className='h-2 flex-1 rounded-full bg-slate-100 overflow-hidden flex'>
+                                        <div
+                                            className='bg-blue-500 h-full'
+                                            style={{
+                                                width: `${(lbWards.reduce((acc, curr) => acc + (curr.male_voters || 0), 0) / totalVoters) * 100}%`,
+                                            }}
+                                        />
+                                        <div
+                                            className='bg-pink-500 h-full'
+                                            style={{
+                                                width: `${(lbWards.reduce((acc, curr) => acc + (curr.female_voters || 0), 0) / totalVoters) * 100}%`,
+                                            }}
+                                        />
+                                        <div
+                                            className='bg-slate-400 h-full'
+                                            style={{
+                                                width: `${(lbWards.reduce((acc, curr) => acc + (curr.other_voters || 0), 0) / totalVoters) * 100}%`,
+                                            }}
+                                        />
                                     </div>
                                 </div>
-                                <div className="space-y-2">
-                                    <div className="flex justify-between items-center text-xs text-slate-600">
-                                        <span className="flex items-center gap-2">
-                                            <span className="w-2 h-2 rounded-full bg-blue-500"></span>
+                                <div className='space-y-2'>
+                                    <div className='flex justify-between items-center text-xs text-slate-600'>
+                                        <span className='flex items-center gap-2'>
+                                            <span className='w-2 h-2 rounded-full bg-blue-500'></span>
                                             Male
                                         </span>
-                                        <span className="font-semibold">{lbWards.reduce((acc, curr) => acc + (curr.male_voters || 0), 0).toLocaleString()}</span>
+                                        <span className='font-semibold'>
+                                            {lbWards
+                                                .reduce(
+                                                    (acc, curr) =>
+                                                        acc +
+                                                        (curr.male_voters || 0),
+                                                    0,
+                                                )
+                                                .toLocaleString()}
+                                        </span>
                                     </div>
-                                    <div className="flex justify-between items-center text-xs text-slate-600">
-                                        <span className="flex items-center gap-2">
-                                            <span className="w-2 h-2 rounded-full bg-pink-500"></span>
+                                    <div className='flex justify-between items-center text-xs text-slate-600'>
+                                        <span className='flex items-center gap-2'>
+                                            <span className='w-2 h-2 rounded-full bg-pink-500'></span>
                                             Female
                                         </span>
-                                        <span className="font-semibold">{lbWards.reduce((acc, curr) => acc + (curr.female_voters || 0), 0).toLocaleString()}</span>
+                                        <span className='font-semibold'>
+                                            {lbWards
+                                                .reduce(
+                                                    (acc, curr) =>
+                                                        acc +
+                                                        (curr.female_voters ||
+                                                            0),
+                                                    0,
+                                                )
+                                                .toLocaleString()}
+                                        </span>
                                     </div>
-                                    <div className="flex justify-between items-center text-xs text-slate-600">
-                                        <span className="flex items-center gap-2">
-                                            <span className="w-2 h-2 rounded-full bg-slate-400"></span>
+                                    <div className='flex justify-between items-center text-xs text-slate-600'>
+                                        <span className='flex items-center gap-2'>
+                                            <span className='w-2 h-2 rounded-full bg-slate-400'></span>
                                             Others
                                         </span>
-                                        <span className="font-semibold">{lbWards.reduce((acc, curr) => acc + (curr.other_voters || 0), 0).toLocaleString()}</span>
+                                        <span className='font-semibold'>
+                                            {lbWards
+                                                .reduce(
+                                                    (acc, curr) =>
+                                                        acc +
+                                                        (curr.other_voters ||
+                                                            0),
+                                                    0,
+                                                )
+                                                .toLocaleString()}
+                                        </span>
                                     </div>
                                 </div>
                             </div>
                         </div>
 
                         {/* Polling Stations Card */}
-                        <div className="p-3 md:p-5 bg-white rounded-2xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow">
-                            <div className="flex items-center gap-3 md:gap-4 h-full">
-                                <div className="p-3 bg-emerald-50 text-emerald-600 rounded-xl shrink-0">
+                        <div className='p-3 md:p-5 bg-white rounded-2xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow'>
+                            <div className='flex items-center gap-3 md:gap-4 h-full'>
+                                <div className='p-3 bg-emerald-50 text-emerald-600 rounded-xl shrink-0'>
                                     <MapPin size={24} />
                                 </div>
                                 <div>
-                                    <p className="text-xs md:text-sm font-medium text-slate-500 mb-1">Polling Stations</p>
-                                    <p className="text-lg md:text-2xl font-bold text-slate-900">{totalPollingStations.toLocaleString()}</p>
+                                    <p className='text-xs md:text-sm font-medium text-slate-500 mb-1'>
+                                        Polling Stations
+                                    </p>
+                                    <p className='text-lg md:text-2xl font-bold text-slate-900'>
+                                        {totalPollingStations.toLocaleString()}
+                                    </p>
                                 </div>
                             </div>
                         </div>
 
                         {/* Wards Card */}
-                        <div className="p-3 md:p-5 bg-white rounded-2xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow">
-                            <div className="flex items-center gap-3 md:gap-4 h-full">
-                                <div className="p-3 bg-amber-50 text-amber-600 rounded-xl shrink-0">
+                        <div className='p-3 md:p-5 bg-white rounded-2xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow'>
+                            <div className='flex items-center gap-3 md:gap-4 h-full'>
+                                <div className='p-3 bg-amber-50 text-amber-600 rounded-xl shrink-0'>
                                     <Building2 size={24} />
                                 </div>
                                 <div>
-                                    <p className="text-xs md:text-sm font-medium text-slate-500 mb-1">Total Wards</p>
-                                    <p className="text-lg md:text-2xl font-bold text-slate-900">{localBody.total_wards}</p>
+                                    <p className='text-xs md:text-sm font-medium text-slate-500 mb-1'>
+                                        Total Wards
+                                    </p>
+                                    <p className='text-lg md:text-2xl font-bold text-slate-900'>
+                                        {localBody.total_wards}
+                                    </p>
                                 </div>
                             </div>
                         </div>
                     </div>
 
-                    <div className="mt-8">
-                        <h3 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-2">
-                            <Users size={20} className="text-slate-400" />
+                    <div className='mt-8'>
+                        <h3 className='text-lg font-bold text-slate-900 mb-4 flex items-center gap-2'>
+                            <Users size={20} className='text-slate-400' />
                             Ward Breakdown
                         </h3>
-                        <div className="bg-slate-50 rounded-2xl border border-slate-200 shadow-inner p-4 overflow-hidden">
-                            <div className="max-h-[500px] overflow-y-auto custom-scrollbar pr-2">
-                                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                        <div className='bg-slate-50 rounded-2xl border border-slate-200 shadow-inner p-4 overflow-hidden'>
+                            <div className='max-h-[500px] overflow-y-auto custom-scrollbar pr-2'>
+                                <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'>
                                     {lbWards.map((ward) => {
-                                        const trendWard = trendData?.wardInfo?.[String(ward.ward_no)];
+                                        const trendWard =
+                                            trendData?.wardInfo?.[
+                                                String(ward.ward_no)
+                                            ];
                                         const winner = trendWard?.winner;
 
                                         // Logic copied from WardDetailModal for consistency
-                                        const topCandidate = trendWard?.candidates?.[0];
+                                        const topCandidate =
+                                            trendWard?.candidates?.[0];
 
-                                        const isUncontested = trendWard?.candidates?.length === 1;
+                                        const isUncontested =
+                                            trendWard?.candidates?.length === 1;
                                         const isHung = trendWard?.isHung;
-                                        const isTieBreak = trendWard?.isTieBreak;
+                                        const isTieBreak =
+                                            trendWard?.isTieBreak;
 
-                                        const isImplicitLead = !winner && !trendWard?.leading && topCandidate && (topCandidate.votes > 0 || isUncontested);
-                                        const leader = trendWard?.leading || (isImplicitLead ? topCandidate : undefined);
+                                        const isImplicitLead =
+                                            !winner &&
+                                            !trendWard?.leading &&
+                                            topCandidate &&
+                                            (topCandidate.votes > 0 ||
+                                                isUncontested);
+                                        const leader =
+                                            trendWard?.leading ||
+                                            (isImplicitLead
+                                                ? topCandidate
+                                                : undefined);
 
-                                        const displayResult = isHung ? null : (winner || leader || topCandidate);
+                                        const displayResult = isHung
+                                            ? null
+                                            : winner || leader || topCandidate;
 
                                         // Determine styling based on status
-                                        let borderColor = 'border-l-4 border-l-slate-300';
+                                        let borderColor =
+                                            'border-l-4 border-l-slate-300';
                                         let statusBadge = null;
 
                                         if (isHung) {
-                                            borderColor = 'border-l-4 border-l-purple-600';
-                                            statusBadge = <span className="text-[10px] bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded font-bold">HUNG</span>;
+                                            borderColor =
+                                                'border-l-4 border-l-purple-600';
+                                            statusBadge = (
+                                                <span className='text-[10px] bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded font-bold'>
+                                                    HUNG
+                                                </span>
+                                            );
                                         } else if (winner) {
-                                            borderColor = winner.group === 'LDF' ? 'border-l-4 border-l-red-500' :
-                                                winner.group === 'UDF' ? 'border-l-4 border-l-indigo-500' :
-                                                    winner.group === 'NDA' ? 'border-l-4 border-l-orange-500' :
-                                                        'border-l-4 border-l-slate-500';
+                                            borderColor =
+                                                winner.group === 'LDF'
+                                                    ? 'border-l-4 border-l-red-500'
+                                                    : winner.group === 'UDF'
+                                                      ? 'border-l-4 border-l-indigo-500'
+                                                      : winner.group === 'NDA'
+                                                        ? 'border-l-4 border-l-orange-500'
+                                                        : 'border-l-4 border-l-slate-500';
 
                                             if (isTieBreak) {
-                                                statusBadge = <span className="text-[10px] bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded font-bold border border-amber-200">WON (TIE)</span>;
+                                                statusBadge = (
+                                                    <span className='text-[10px] bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded font-bold border border-amber-200'>
+                                                        WON (TIE)
+                                                    </span>
+                                                );
                                             } else {
-                                                statusBadge = <span className="text-[10px] bg-emerald-100 text-emerald-700 px-1.5 py-0.5 rounded font-bold">WON</span>;
+                                                statusBadge = (
+                                                    <span className='text-[10px] bg-emerald-100 text-emerald-700 px-1.5 py-0.5 rounded font-bold'>
+                                                        WON
+                                                    </span>
+                                                );
                                             }
                                         } else if (leader) {
-                                            borderColor = leader.group === 'LDF' ? 'border-l-4 border-l-red-400' :
-                                                leader.group === 'UDF' ? 'border-l-4 border-l-indigo-400' :
-                                                    leader.group === 'NDA' ? 'border-l-4 border-l-orange-400' :
-                                                        'border-l-4 border-l-slate-400';
-                                            statusBadge = <span className="text-[10px] bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded font-bold">LEAD</span>;
+                                            borderColor =
+                                                leader.group === 'LDF'
+                                                    ? 'border-l-4 border-l-red-400'
+                                                    : leader.group === 'UDF'
+                                                      ? 'border-l-4 border-l-indigo-400'
+                                                      : leader.group === 'NDA'
+                                                        ? 'border-l-4 border-l-orange-400'
+                                                        : 'border-l-4 border-l-slate-400';
+                                            statusBadge = (
+                                                <span className='text-[10px] bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded font-bold'>
+                                                    LEAD
+                                                </span>
+                                            );
                                         }
 
                                         // Text Color for Party/Group
                                         const groupColor =
-                                            displayResult?.group === 'LDF' ? 'text-red-700' :
-                                                displayResult?.group === 'UDF' ? 'text-indigo-700' :
-                                                    displayResult?.group === 'NDA' ? 'text-orange-700' :
-                                                        'text-slate-600';
+                                            displayResult?.group === 'LDF'
+                                                ? 'text-red-700'
+                                                : displayResult?.group === 'UDF'
+                                                  ? 'text-indigo-700'
+                                                  : displayResult?.group ===
+                                                      'NDA'
+                                                    ? 'text-orange-700'
+                                                    : 'text-slate-600';
 
                                         return (
                                             <div
                                                 key={ward.ward_code}
-                                                onClick={() => setSelectedWard(String(ward.ward_no))}
+                                                onClick={() =>
+                                                    setSelectedWard(
+                                                        String(ward.ward_no),
+                                                    )
+                                                }
                                                 className={`bg-white p-3 rounded-lg border border-slate-200 shadow-sm hover:shadow-md transition-all cursor-pointer flex flex-col justify-between group ${borderColor}`}
                                             >
-                                                <div className="flex justify-between items-start mb-2">
+                                                <div className='flex justify-between items-start mb-2'>
                                                     <div>
-                                                        <div className="text-xs font-bold text-slate-400 uppercase tracking-wider">Ward {ward.ward_no}</div>
-                                                        <div className="font-semibold text-slate-900 text-sm line-clamp-1" title={ward.ward_name_english}>{ward.ward_name_english}</div>
+                                                        <div className='text-xs font-bold text-slate-400 uppercase tracking-wider'>
+                                                            Ward {ward.ward_no}
+                                                        </div>
+                                                        <div
+                                                            className='font-semibold text-slate-900 text-sm line-clamp-1'
+                                                            title={
+                                                                ward.ward_name_english
+                                                            }
+                                                        >
+                                                            {
+                                                                ward.ward_name_english
+                                                            }
+                                                        </div>
                                                     </div>
                                                     {statusBadge}
                                                 </div>
 
                                                 {trendData ? (
-                                                    <div className="bg-slate-50 rounded p-2 text-xs">
+                                                    <div className='bg-slate-50 rounded p-2 text-xs'>
                                                         {isHung ? (
-                                                            <div className="flex items-center justify-between font-bold text-purple-700">
-                                                                <span>TIED</span>
+                                                            <div className='flex items-center justify-between font-bold text-purple-700'>
+                                                                <span>
+                                                                    TIED
+                                                                </span>
                                                             </div>
                                                         ) : displayResult ? (
-                                                            <div className="flex items-center justify-between">
-                                                                <span className={`font-bold truncate w-full ${groupColor}`}>{displayResult.name}</span>
+                                                            <div className='flex items-center justify-between'>
+                                                                <span
+                                                                    className={`font-bold truncate w-full ${groupColor}`}
+                                                                >
+                                                                    {
+                                                                        displayResult.name
+                                                                    }
+                                                                </span>
                                                             </div>
                                                         ) : (
-                                                            <div className="text-slate-400 italic text-center text-[10px]">No Result</div>
-                                                        )}
-                                                        {(!isHung && displayResult) && (
-                                                            <div className="flex justify-between mt-1 text-[10px] text-slate-500">
-                                                                <span>{displayResult.party}</span>
-                                                                <span>{displayResult.group}</span>
+                                                            <div className='text-slate-400 italic text-center text-[10px]'>
+                                                                No Result
                                                             </div>
                                                         )}
+                                                        {!isHung &&
+                                                            displayResult && (
+                                                                <div className='flex justify-between mt-1 text-[10px] text-slate-500'>
+                                                                    <span>
+                                                                        {
+                                                                            displayResult.party
+                                                                        }
+                                                                    </span>
+                                                                    <span>
+                                                                        {
+                                                                            displayResult.group
+                                                                        }
+                                                                    </span>
+                                                                </div>
+                                                            )}
                                                     </div>
                                                 ) : (
-                                                    <div className="mt-2 text-right">
-                                                        <span className="text-xs text-slate-400">Voters: </span>
-                                                        <span className="text-xs font-mono font-medium text-slate-600">{ward.total_voters.toLocaleString()}</span>
+                                                    <div className='mt-2 text-right'>
+                                                        <span className='text-xs text-slate-400'>
+                                                            Voters:{' '}
+                                                        </span>
+                                                        <span className='text-xs font-mono font-medium text-slate-600'>
+                                                            {ward.total_voters.toLocaleString()}
+                                                        </span>
                                                     </div>
                                                 )}
                                             </div>

--- a/src/components/details/WardDetailModal.tsx
+++ b/src/components/details/WardDetailModal.tsx
@@ -9,7 +9,12 @@ interface WardDetailModalProps {
     trendData?: TrendResult;
 }
 
-export const WardDetailModal: React.FC<WardDetailModalProps> = ({ isOpen, onClose, wardNo, trendData }) => {
+export const WardDetailModal: React.FC<WardDetailModalProps> = ({
+    isOpen,
+    onClose,
+    wardNo,
+    trendData,
+}) => {
     if (!isOpen || !wardNo || !trendData) return null;
 
     const info = trendData.wardInfo?.[wardNo];
@@ -20,166 +25,299 @@ export const WardDetailModal: React.FC<WardDetailModalProps> = ({ isOpen, onClos
     const topCandidate = info.candidates?.[0];
     const secondCandidate = info.candidates?.[1];
     const isUncontested = info.candidates?.length === 1;
-    const isHung = !isUncontested && topCandidate && secondCandidate && topCandidate.votes > 0 && topCandidate.votes === secondCandidate.votes;
+    const isHung =
+        !isUncontested &&
+        topCandidate &&
+        secondCandidate &&
+        topCandidate.votes > 0 &&
+        topCandidate.votes === secondCandidate.votes;
 
     // Implicit lead logic
-    const isImplicitLead = !winner && !info.leading && topCandidate && (topCandidate.votes > 0 || isUncontested);
+    const isImplicitLead =
+        !winner &&
+        !info.leading &&
+        topCandidate &&
+        (topCandidate.votes > 0 || isUncontested);
     const leader = info.leading || (isImplicitLead ? topCandidate : undefined);
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6">
+        <div className='fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6'>
             {/* Backdrop */}
             <div
-                className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm transition-opacity"
+                className='absolute inset-0 bg-slate-900/40 backdrop-blur-sm transition-opacity'
                 onClick={onClose}
             />
 
             {/* Modal Content */}
-            <div className="relative bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[85dvh] animate-in fade-in zoom-in-95 duration-200">
+            <div className='relative bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[85dvh] animate-in fade-in zoom-in-95 duration-200'>
                 {/* Header */}
                 {/* Header */}
-                <div className="px-4 py-3 sm:px-6 sm:py-4 border-b border-slate-100 flex items-center justify-between bg-white z-10 shrink-0 sticky top-0">
-                    <div className="flex-1 min-w-0 pr-4">
-                        <h3 className="text-xl font-bold text-slate-900 truncate">Ward {wardNo}</h3>
-                        <p className="text-sm text-slate-500 font-medium truncate">{info.wardName}</p>
+                <div className='px-4 py-3 sm:px-6 sm:py-4 border-b border-slate-100 flex items-center justify-between bg-white z-10 shrink-0 sticky top-0'>
+                    <div className='flex-1 min-w-0 pr-4'>
+                        <h3 className='text-xl font-bold text-slate-900 truncate'>
+                            Ward {wardNo}
+                        </h3>
+                        <p className='text-sm text-slate-500 font-medium truncate'>
+                            {info.wardName}
+                        </p>
                     </div>
 
                     <button
                         onClick={onClose}
-                        className="p-2 rounded-full hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors shrink-0"
+                        className='p-2 rounded-full hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors shrink-0'
                     >
                         <X size={20} />
                     </button>
                 </div>
 
                 {/* Body */}
-                <div className="p-4 sm:p-6 overflow-y-auto custom-scrollbar">
+                <div className='p-4 sm:p-6 overflow-y-auto custom-scrollbar'>
                     {/* Status Banner */}
-                    <div className="mb-6">
+                    <div className='mb-6'>
                         {isHung ? (
-                            <div className="bg-purple-50 border border-purple-100 rounded-xl p-4 flex items-center gap-3">
-                                <div className="p-2 bg-purple-100 text-purple-600 rounded-lg">
+                            <div className='bg-purple-50 border border-purple-100 rounded-xl p-4 flex items-center gap-3'>
+                                <div className='p-2 bg-purple-100 text-purple-600 rounded-lg'>
                                     <Trophy size={20} />
                                 </div>
                                 <div>
-                                    <div className="font-bold text-purple-700">TIED / HUNG ELECTION</div>
-                                    <div className="text-xs text-purple-600 mt-0.5">Equal votes for top candidates</div>
+                                    <div className='font-bold text-purple-700'>
+                                        TIED / HUNG ELECTION
+                                    </div>
+                                    <div className='text-xs text-purple-600 mt-0.5'>
+                                        Equal votes for top candidates
+                                    </div>
                                 </div>
                             </div>
-                        ) : (isUncontested && winner) ? (
-                            <div className="bg-purple-50 border border-purple-100 rounded-xl p-4 flex items-center gap-3">
-                                <div className="p-2 bg-purple-100 text-purple-600 rounded-lg">
+                        ) : isUncontested && winner ? (
+                            <div className='bg-purple-50 border border-purple-100 rounded-xl p-4 flex items-center gap-3'>
+                                <div className='p-2 bg-purple-100 text-purple-600 rounded-lg'>
                                     <Trophy size={20} />
                                 </div>
                                 <div>
-                                    <div className="font-bold text-purple-700">ELECTED UNOPPOSED</div>
-                                    <div className="text-xs text-purple-600 mt-0.5">
+                                    <div className='font-bold text-purple-700'>
+                                        ELECTED UNOPPOSED
+                                    </div>
+                                    <div className='text-xs text-purple-600 mt-0.5'>
                                         Winner: {winner.name} ({winner.group})
                                     </div>
                                 </div>
                             </div>
                         ) : winner ? (
-                            <div className={`
+                            <div
+                                className={`
                                 border rounded-xl p-4 flex items-center gap-3
-                                ${winner.group === 'LDF' ? 'bg-red-50 border-red-100' :
-                                    winner.group === 'UDF' ? 'bg-indigo-50 border-indigo-100' :
-                                        winner.group === 'NDA' ? 'bg-orange-50 border-orange-100' :
-                                            'bg-slate-50 border-slate-100'}
-                            `}>
-                                <div className={`
+                                ${
+                                    winner.group === 'LDF'
+                                        ? 'bg-red-50 border-red-100'
+                                        : winner.group === 'UDF'
+                                          ? 'bg-indigo-50 border-indigo-100'
+                                          : winner.group === 'NDA'
+                                            ? 'bg-orange-50 border-orange-100'
+                                            : 'bg-slate-50 border-slate-100'
+                                }
+                            `}
+                            >
+                                <div
+                                    className={`
                                     p-2 rounded-lg
-                                    ${winner.group === 'LDF' ? 'bg-red-100 text-red-600' :
-                                        winner.group === 'UDF' ? 'bg-indigo-100 text-indigo-600' :
-                                            winner.group === 'NDA' ? 'bg-orange-100 text-orange-600' :
-                                                'bg-slate-200 text-slate-600'}
-                                `}>
+                                    ${
+                                        winner.group === 'LDF'
+                                            ? 'bg-red-100 text-red-600'
+                                            : winner.group === 'UDF'
+                                              ? 'bg-indigo-100 text-indigo-600'
+                                              : winner.group === 'NDA'
+                                                ? 'bg-orange-100 text-orange-600'
+                                                : 'bg-slate-200 text-slate-600'
+                                    }
+                                `}
+                                >
                                     <Trophy size={20} />
                                 </div>
                                 <div>
-                                    <div className={`font-bold ${winner.group === 'LDF' ? 'text-red-700' :
-                                        winner.group === 'UDF' ? 'text-indigo-700' :
-                                            winner.group === 'NDA' ? 'text-orange-700' :
-                                                'text-slate-700'
-                                        }`}>
+                                    <div
+                                        className={`font-bold ${
+                                            winner.group === 'LDF'
+                                                ? 'text-red-700'
+                                                : winner.group === 'UDF'
+                                                  ? 'text-indigo-700'
+                                                  : winner.group === 'NDA'
+                                                    ? 'text-orange-700'
+                                                    : 'text-slate-700'
+                                        }`}
+                                    >
                                         WINNER: {winner.name} ({winner.group})
                                     </div>
-                                    <div className="text-xs opacity-80 mt-0.5">
-                                        {secondCandidate ? `Won by margin of ${(winner.votes - secondCandidate.votes).toLocaleString()} votes` : `Won with ${winner.votes.toLocaleString()} votes`}
+                                    <div className='text-xs opacity-80 mt-0.5'>
+                                        {secondCandidate
+                                            ? `Won by margin of ${(winner.votes - secondCandidate.votes).toLocaleString()} votes`
+                                            : `Won with ${winner.votes.toLocaleString()} votes`}
                                     </div>
                                 </div>
                             </div>
                         ) : leader ? (
-                            <div className="bg-blue-50 border border-blue-100 rounded-xl p-4 flex items-center gap-3">
-                                <div className="p-2 bg-blue-100 text-blue-600 rounded-lg">
+                            <div className='bg-blue-50 border border-blue-100 rounded-xl p-4 flex items-center gap-3'>
+                                <div className='p-2 bg-blue-100 text-blue-600 rounded-lg'>
                                     <Trophy size={20} />
                                 </div>
                                 <div>
-                                    <div className="font-bold text-blue-700">LEADING: {leader.name} ({leader.group})</div>
-                                    <div className="text-xs text-blue-600 mt-0.5">Currently leading with {leader.votes.toLocaleString()} votes</div>
+                                    <div className='font-bold text-blue-700'>
+                                        LEADING: {leader.name} ({leader.group})
+                                    </div>
+                                    <div className='text-xs text-blue-600 mt-0.5'>
+                                        Currently leading with{' '}
+                                        {leader.votes.toLocaleString()} votes
+                                    </div>
                                 </div>
                             </div>
                         ) : (
-                            <div className="bg-slate-50 border border-slate-100 rounded-xl p-4 text-center text-slate-500 font-medium">
+                            <div className='bg-slate-50 border border-slate-100 rounded-xl p-4 text-center text-slate-500 font-medium'>
                                 No result available
                             </div>
                         )}
                     </div>
 
                     {/* Candidates List */}
-                    <div className="space-y-3">
-                        <h4 className="text-sm font-semibold text-slate-900 uppercase tracking-wider mb-3">Candidates</h4>
-                        {info.candidates.map((cand, idx) => {
-                            const isWinner = cand.status?.toLowerCase() === 'won';
-                            const maxVotes = Math.max(...info.candidates.map(c => c.votes));
-                            const percent = isUncontested ? 100 : (maxVotes > 0 ? (cand.votes / maxVotes) * 100 : 0);
+                    {/* Candidates List */}
+                    <div className='space-y-3'>
+                        <h4 className='text-sm font-semibold text-slate-900 uppercase tracking-wider mb-3'>
+                            Candidates
+                        </h4>
 
-                            return (
-                                <div key={idx} className={`relative overflow-hidden rounded-xl border ${isWinner ? 'border-yellow-200 bg-yellow-50/50' : 'border-slate-100 bg-white'}`}>
-                                    {/* Probability Bar Background */}
+                        {(() => {
+                            const totalWardVotes = info.candidates.reduce(
+                                (sum, c) => sum + (c.votes ?? 0),
+                                0,
+                            );
+                            const maxVotes = Math.max(
+                                ...info.candidates.map((c) => c.votes ?? 0),
+                            );
+
+                            return info.candidates.map((cand, idx) => {
+                                const isWinner =
+                                    cand.status?.toLowerCase() === 'won';
+
+                                const barPercent = isUncontested
+                                    ? 100
+                                    : maxVotes > 0
+                                      ? (cand.votes / maxVotes) * 100
+                                      : 0;
+
+                                const voteSharePercent =
+                                    totalWardVotes > 0
+                                        ? (
+                                              (cand.votes / totalWardVotes) *
+                                              100
+                                          ).toFixed(1)
+                                        : '0.0';
+
+                                const margin =
+                                    isWinner && info.candidates.length > 1
+                                        ? cand.votes -
+                                          (info.candidates.find(
+                                              (c) => !isWinner || c !== cand,
+                                          )?.votes ?? 0)
+                                        : null;
+
+                                // Recompute runner-up properly
+                                const sortedByVotes = [...info.candidates].sort(
+                                    (a, b) => (b.votes ?? 0) - (a.votes ?? 0),
+                                );
+                                const winMargin =
+                                    isWinner && sortedByVotes.length > 1
+                                        ? cand.votes - sortedByVotes[1].votes
+                                        : null;
+
+                                return (
                                     <div
-                                        className={`absolute inset-0 opacity-5 ${cand.group === 'LDF' ? 'bg-red-500' :
-                                            cand.group === 'UDF' ? 'bg-indigo-500' :
-                                                cand.group === 'NDA' ? 'bg-orange-500' :
-                                                    'bg-slate-400'
+                                        key={idx}
+                                        className={`relative overflow-hidden rounded-xl border ${
+                                            isWinner
+                                                ? 'border-yellow-200 bg-yellow-50/50'
+                                                : 'border-slate-100 bg-white'
+                                        }`}
+                                    >
+                                        {/* Bar Background */}
+                                        <div
+                                            className={`absolute inset-y-0 left-0 opacity-[0.07] ${
+                                                cand.group === 'LDF'
+                                                    ? 'bg-red-500'
+                                                    : cand.group === 'UDF'
+                                                      ? 'bg-indigo-500'
+                                                      : cand.group === 'NDA'
+                                                        ? 'bg-orange-500'
+                                                        : 'bg-slate-400'
                                             }`}
-                                        style={{ width: `${percent}%` }}
-                                    />
+                                            style={{ width: `${barPercent}%` }}
+                                        />
 
-                                    <div className="relative p-3">
-                                        <div className="flex justify-between items-start mb-1">
-                                            <div className="font-bold text-slate-800 text-sm">{cand.name}</div>
-                                            {isWinner && (
-                                                <span className="text-[10px] font-bold text-emerald-600 bg-emerald-100 px-1.5 py-0.5 rounded ml-2 shrink-0">
-                                                    WINNER
+                                        <div className='relative p-3'>
+                                            {/* Name + Winner badge */}
+                                            <div className='flex justify-between items-start mb-1.5'>
+                                                <div className='font-bold text-slate-800 text-sm'>
+                                                    {cand.name}
+                                                </div>
+                                                {isWinner && (
+                                                    <span className='text-[10px] font-bold text-emerald-600 bg-emerald-100 px-1.5 py-0.5 rounded ml-2 shrink-0'>
+                                                        WINNER
+                                                    </span>
+                                                )}
+                                            </div>
+
+                                            {/* Party + Votes + % */}
+                                            <div className='flex justify-between items-center text-xs'>
+                                                <span
+                                                    className={`font-semibold ${
+                                                        cand.group === 'LDF'
+                                                            ? 'text-red-600'
+                                                            : cand.group ===
+                                                                'UDF'
+                                                              ? 'text-indigo-600'
+                                                              : cand.group ===
+                                                                  'NDA'
+                                                                ? 'text-orange-600'
+                                                                : 'text-slate-600'
+                                                    }`}
+                                                >
+                                                    {cand.party}
+                                                    <span className='ml-1.5 text-slate-400 font-normal'>
+                                                        {cand.group}
+                                                    </span>
                                                 </span>
+                                                <div className='flex items-center gap-2'>
+                                                    <span className='text-slate-400 font-medium'>
+                                                        {voteSharePercent}%
+                                                    </span>
+                                                    <span className='font-mono font-bold text-slate-900 bg-white/70 px-1.5 py-0.5 rounded border border-slate-100'>
+                                                        {cand.votes.toLocaleString()}
+                                                    </span>
+                                                </div>
+                                            </div>
+
+                                            {/* Win margin — only on winner row */}
+                                            {isWinner && winMargin !== null && (
+                                                <div className='mt-1.5 text-[11px] text-slate-400'>
+                                                    Won by{' '}
+                                                    <span className='font-semibold text-emerald-600'>
+                                                        +
+                                                        {winMargin.toLocaleString()}
+                                                    </span>{' '}
+                                                    votes
+                                                </div>
                                             )}
                                         </div>
-
-                                        <div className="flex justify-between items-center text-xs">
-                                            <span className={`font-semibold ${cand.group === 'LDF' ? 'text-red-600' :
-                                                cand.group === 'UDF' ? 'text-indigo-600' :
-                                                    cand.group === 'NDA' ? 'text-orange-600' :
-                                                        'text-slate-600'
-                                                }`}>
-                                                {cand.party}
-                                            </span>
-                                            <span className="font-mono font-bold text-slate-900 bg-white/50 px-1.5 rounded">
-                                                {cand.votes.toLocaleString()}
-                                            </span>
-                                        </div>
                                     </div>
-                                </div>
-                            );
-                        })}
+                                );
+                            });
+                        })()}
 
                         {(!info.candidates || info.candidates.length === 0) && (
-                            <div className="text-center py-8 text-slate-400 italic text-sm">
+                            <div className='text-center py-8 text-slate-400 italic text-sm'>
                                 No candidate data available for this ward.
                             </div>
                         )}
                     </div>
                 </div>
             </div>
-        </div >
+        </div>
     );
 };


### PR DESCRIPTION
## Updates
Seat % label shown inline (e.g. 9 (47%))
Vote share sub-bar added to compare seat vs vote %
Party breakdown (expandable) with wins (W) and vote %
Stacked overview bar for all fronts in Leading Front card
Computation scoped using IIFE (no component pollution)
<img width="602" height="263" alt="image" src="https://github.com/user-attachments/assets/2f1682e1-76db-4b2e-ad10-db2c5b56b177" />

##  Detail Modal
Accurate vote share % = votes / totalWardVotes
Win margin shown for winner (e.g. +83 votes)
Party + group label (e.g. INC · UDF)
<img width="237" height="277" alt="image" src="https://github.com/user-attachments/assets/2a0d7ab0-8918-4aff-817c-ead61f15722e" />

## Impact

Improves clarity of seat vs vote share, adds better insights and cleaner UI.